### PR TITLE
Update scadenza logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,14 @@ VS, BF, BT, VF e LP.
 from lost_and_found import utils
 
 # Aggiungi un oggetto
+stato = "avvisato"  # oppure "non_avvisato"
 utils.aggiungi_oggetto(
     villa="VS",
     data_ritrovamento="2025-01-01",
     ora_ritrovamento="10:00",
-    stato_notifica="non_avvisato",
-    giorni_scadenza=30,
+    stato_notifica=stato,
+    # 30 giorni se avvisato, altrimenti 90
+    giorni_scadenza=30 if stato == "avvisato" else 90,
     utente="Mario Rossi",
     foto="/percorso/alla/foto.jpg"
 )

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -18,7 +18,6 @@ if menu == "Aggiungi oggetto":
         data_r = st.date_input("Data di ritrovamento", value=date.today())
         ora_r = st.time_input("Ora di ritrovamento", value=datetime.now().time())
         stato = st.selectbox("Stato notifica", ["non_avvisato", "avvisato"])
-        giorni = st.number_input("Giorni alla scadenza", min_value=1, max_value=365, value=30)
         utente = st.text_input("Utente")
         foto = st.file_uploader("Foto", type=["jpg", "jpeg", "png"])
         submit = st.form_submit_button("Salva")
@@ -30,12 +29,13 @@ if menu == "Aggiungi oggetto":
                 foto_path = os.path.join(upload_dir, foto.name)
                 with open(foto_path, "wb") as f:
                     f.write(foto.read())
+            giorni_scadenza = 30 if stato == "avvisato" else 90
             item = utils.aggiungi_oggetto(
                 villa=villa,
                 data_ritrovamento=data_r.strftime("%Y-%m-%d"),
                 ora_ritrovamento=ora_r.strftime("%H:%M"),
                 stato_notifica=stato,
-                giorni_scadenza=int(giorni),
+                giorni_scadenza=giorni_scadenza,
                 utente=utente,
                 foto=foto_path,
             )


### PR DESCRIPTION
## Summary
- remove custom expiry input from streamlit app and compute scadenza based on `stato`
- show dynamic expiry calculation in README usage example

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68420e1d060c8323af5e84048b506f08