### PR TITLE
Update README for new archive workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,21 @@ VS, BF, BT, VF e LP.
 
 ## Funzionalità principali
 
-- Aggiungi un oggetto smarrito
+- Aggiungi un oggetto smarrito specificando il nome del proprietario
 - Segna un oggetto come ritirato
-- Archivia automaticamente gli oggetti scaduti
+- Archivia automaticamente gli oggetti scaduti in base alla loro data di
+  scadenza
 - Gestione delle foto
-- Script di schedulazione quotidiana
+- Script di schedulazione quotidiana per l'archiviazione
+- Ricerca e consultazione dell'archivio dalla voce "Archivio"
 
 ## Utilizzo
+
+Ogni oggetto viene archiviato automaticamente alla data di scadenza
+calcolata al momento dell'inserimento. Normalmente gli oggetti avvisati
+scadono dopo **30 giorni**, quelli non avvisati dopo **90**. Il campo
+`proprietario` permette di registrare il nominativo associato all'oggetto
+ritrovato.
 
 ```python
 from lost_and_found import utils
@@ -28,6 +36,10 @@ utils.aggiungi_oggetto(
     proprietario="Mario Rossi",
     foto="/percorso/alla/foto.jpg"
 )
+
+# L'oggetto scadrà automaticamente dopo il numero di giorni indicato
+# e verrà spostato nell'archivio al passaggio dello scheduler o con:
+# utils.archivia_scaduti()
 
 # Segna ritiro
 utils.ritiro_oggetto("001-VS", "2025-01-15")
@@ -47,4 +59,6 @@ streamlit run streamlit_app.py
 ```
 
 Da qui si possono inserire nuovi oggetti, cercare tra quelli presenti e
-archiviare quelli scaduti.
+archiviare quelli scaduti. Dal menu laterale è ora disponibile anche la
+voce **Archivio** per consultare gli oggetti già archiviati e cercarli per
+ID, villa o nome del proprietario.


### PR DESCRIPTION
## Summary
- document automatic expiry logic and owner name field
- mention the new Archivio menu
- update example to show updated function signatures and behaviour

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6842931a3aa08323bef95c3a53869ba8