### PR TITLE
Add tabulate to requirements and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ ID, villa o nome del proprietario.
 
 ## Installazione
 
-Per installare le dipendenze necessarie utilizzare:
+Per installare le dipendenze necessarie, inclusa `tabulate`, utilizzare:
 
 ```bash
 pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 streamlit
 pandas
 schedule
+tabulate


### PR DESCRIPTION
## Summary
- add `tabulate` to requirements
- mention `tabulate` as a dependency in the README

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68429cbbd77c832398818007261febf6