### PR TITLE
Add descrizione and operatore fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ utils.aggiungi_oggetto(
     # 30 giorni se avvisato, altrimenti 90
     giorni_scadenza=30 if stato == "avvisato" else 90,
     proprietario="Mario Rossi",
+    descrizione="Ombrello nero",
+    operatore="Giulia",
     foto="/percorso/alla/foto.jpg"
 )
 

--- a/lost_and_found/utils.py
+++ b/lost_and_found/utils.py
@@ -42,6 +42,8 @@ CSV_FIELDS = [
     'data_ritrovamento',
     'ora_ritrovamento',
     'stato_notifica',
+    'descrizione',
+    'operatore',
     'data_scadenza',
     'proprietario',
     'ritirato',
@@ -101,9 +103,18 @@ def salva_immagine(path_foto):
     return dest_path
 
 
-def aggiungi_oggetto(villa, data_ritrovamento, ora_ritrovamento,
-                     stato_notifica, giorni_scadenza=30, proprietario=None,
-                     foto=None, logo=None):
+def aggiungi_oggetto(
+    villa,
+    data_ritrovamento,
+    ora_ritrovamento,
+    stato_notifica,
+    giorni_scadenza=30,
+    proprietario=None,
+    descrizione=None,
+    operatore=None,
+    foto=None,
+    logo=None,
+):
     """Create a lost item entry and persist it to disk."""
     items = _load_data(LOST_ITEMS_FILE, LOST_ITEMS_CSV)
     item_id = _next_id(villa, items)
@@ -116,6 +127,8 @@ def aggiungi_oggetto(villa, data_ritrovamento, ora_ritrovamento,
         'data_ritrovamento': data_ritrovamento,
         'ora_ritrovamento': ora_ritrovamento,
         'stato_notifica': stato_notifica,
+        'descrizione': descrizione,
+        'operatore': operatore,
         'data_scadenza': scadenza,
         'proprietario': proprietario,
         'ritirato': False,

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -19,7 +19,12 @@ if menu == "Aggiungi oggetto":
         data_r = st.date_input("Data di ritrovamento", value=date.today())
         ora_r = st.time_input("Ora di ritrovamento", value=datetime.now().time())
         stato = st.selectbox("Stato notifica", ["non_avvisato", "avvisato"])
-        proprietario = st.text_input("Proprietario (nome e cognome)")
+        descrizione = st.text_area("Descrizione")
+        operatore = st.text_input("Operatore")
+        if stato == "avvisato":
+            proprietario = st.text_input("Proprietario (nome e cognome)")
+        else:
+            proprietario = None
         foto = st.file_uploader("Foto", type=["jpg", "jpeg", "png"])
         submit = st.form_submit_button("Salva")
         if submit:
@@ -38,6 +43,8 @@ if menu == "Aggiungi oggetto":
                 stato_notifica=stato,
                 giorni_scadenza=giorni_scadenza,
                 proprietario=proprietario,
+                descrizione=descrizione,
+                operatore=operatore,
                 foto=foto_path,
             )
             st.success(f"Oggetto aggiunto con ID {item['id']}")
@@ -60,6 +67,8 @@ elif menu == "Lista oggetti":
                 "villa": i["villa"],
                 "data/ora ritrovamento": f"{i['data_ritrovamento']} {i['ora_ritrovamento']}",
                 "stato_notifica": i["stato_notifica"],
+                "descrizione": i.get("descrizione"),
+                "operatore": i.get("operatore"),
                 "proprietario": i.get("proprietario"),
                 "ritirato": i.get("ritirato"),
                 "archiviato": i.get("archiviato"),
@@ -121,6 +130,8 @@ else:
                 "villa": i["villa"],
                 "data/ora ritrovamento": f"{i['data_ritrovamento']} {i['ora_ritrovamento']}",
                 "stato_notifica": i["stato_notifica"],
+                "descrizione": i.get("descrizione"),
+                "operatore": i.get("operatore"),
                 "proprietario": i.get("proprietario"),
                 "ritirato": i.get("ritirato"),
                 "archiviato": i.get("archiviato"),


### PR DESCRIPTION
## Summary
- support additional fields `descrizione` and `operatore`
- handle new fields in Streamlit UI and table views
- document new arguments in README

## Testing
- `python -m py_compile streamlit_app.py lost_and_found/utils.py`

------
https://chatgpt.com/codex/tasks/task_e_68429e75eb60832393270fd77b772e8d