### PR TITLE
Fix json saving path creation

### DIFF
--- a/lost_and_found/utils.py
+++ b/lost_and_found/utils.py
@@ -33,6 +33,7 @@ def _load_json(path):
 
 
 def _save_json(path, data):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
     with open(path, 'w', encoding='utf-8') as f:
         json.dump(data, f, indent=2, ensure_ascii=False)
 


### PR DESCRIPTION
## Summary
- ensure `_save_json` creates its output directory before writing
- add a helper to prepare a temp env without directories
- test automatic creation of `lost_and_found/data`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842da7d4668832389722e5812782773